### PR TITLE
Update svgicons2svgfont and add fontHeight option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/build/generators/eot.js
+++ b/build/generators/eot.js
@@ -5,6 +5,6 @@ var TTFToEOT = require('ttf2eot');
 module.exports = function (ttfBuffer) {
   return new Promise(function (resolve) {
     var font = TTFToEOT(new Uint8Array(ttfBuffer));
-    resolve(new Buffer(font.buffer));
+    resolve(Buffer.from(font.buffer));
   });
 };

--- a/build/generators/svgSheet.js
+++ b/build/generators/svgSheet.js
@@ -22,7 +22,7 @@ module.exports = function (fileDirectory, fontName) {
       return prev;
     }, {});
 
-    var fontsSheet = new Buffer(0);
+    var fontsSheet = Buffer.alloc(0);
     var streamOptions = Object.assign({}, SVG_SHEET_OPTIONS, { fontName: fontName });
 
     var fontStream = new svgToSheet(streamOptions).on('data', function (data) {

--- a/build/generators/svgSheet.js
+++ b/build/generators/svgSheet.js
@@ -5,7 +5,8 @@ var fs = require('fs');
 var path = require('path');
 
 var SVG_SHEET_OPTIONS = {
-  normalize: true
+  normalize: true,
+  fontHeight: 1000
 };
 
 var STARTING_CODEPOINT = 0xF101;
@@ -24,7 +25,7 @@ module.exports = function (fileDirectory, fontName) {
     var fontsSheet = new Buffer(0);
     var streamOptions = Object.assign({}, SVG_SHEET_OPTIONS, { fontName: fontName });
 
-    var fontStream = svgToSheet(streamOptions).on('data', function (data) {
+    var fontStream = new svgToSheet(streamOptions).on('data', function (data) {
       fontsSheet = Buffer.concat([fontsSheet, data]);
     }).on('end', function () {
       return resolve({ glyphToCodepoint: glyphToCodepoint, svgSheet: fontsSheet.toString() });

--- a/build/generators/ttf.js
+++ b/build/generators/ttf.js
@@ -5,6 +5,6 @@ var svgSheetToTTF = require('svg2ttf');
 module.exports = function (fontSheet) {
   return new Promise(function (resolve) {
     var font = svgSheetToTTF(fontSheet);
-    resolve(new Buffer(font.buffer));
+    resolve(Buffer.from(font.buffer));
   });
 };

--- a/build/generators/woff.js
+++ b/build/generators/woff.js
@@ -5,6 +5,6 @@ var TTFToWOFF = require('ttf2woff');
 module.exports = function (ttfBuffer) {
   return new Promise(function (resolve) {
     var font = TTFToWOFF(new Uint8Array(ttfBuffer));
-    resolve(new Buffer(font.buffer));
+    resolve(Buffer.from(font.buffer));
   });
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-polyfill": "^6.20.0",
     "fs-extra": "^1.0.0",
     "svg2ttf": "^4.0.2",
-    "svgicons2svgfont": "^5.0.0",
+    "svgicons2svgfont": "^9.0.0",
     "ttf2eot": "^2.0.0",
     "ttf2woff": "^2.0.1",
     "yargs": "^6.0.0"

--- a/src/generators/eot.js
+++ b/src/generators/eot.js
@@ -2,5 +2,5 @@ const TTFToEOT = require('ttf2eot');
 
 module.exports = ttfBuffer => new Promise(resolve => {
   const font = TTFToEOT(new Uint8Array(ttfBuffer));
-  resolve(new Buffer(font.buffer));
+  resolve(Buffer.from(font.buffer));
 });

--- a/src/generators/svgSheet.js
+++ b/src/generators/svgSheet.js
@@ -21,7 +21,7 @@ module.exports = (fileDirectory, fontName) => new Promise(resolve => {
   }, {});
 
 
-  let fontsSheet = new Buffer(0);
+  let fontsSheet = Buffer.alloc(0);
   const streamOptions = Object.assign({}, SVG_SHEET_OPTIONS, { fontName });
 
   const fontStream = (new svgToSheet(streamOptions))

--- a/src/generators/svgSheet.js
+++ b/src/generators/svgSheet.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 const SVG_SHEET_OPTIONS = {
   normalize: true,
+  fontHeight: 1000,
 };
 
 const STARTING_CODEPOINT = 0xF101;
@@ -23,7 +24,7 @@ module.exports = (fileDirectory, fontName) => new Promise(resolve => {
   let fontsSheet = new Buffer(0);
   const streamOptions = Object.assign({}, SVG_SHEET_OPTIONS, { fontName });
 
-  const fontStream = svgToSheet(streamOptions)
+  const fontStream = (new svgToSheet(streamOptions))
     .on('data', data => { fontsSheet = Buffer.concat([fontsSheet, data]); })
     .on('end', () => resolve({ glyphToCodepoint, svgSheet: fontsSheet.toString() }));
 

--- a/src/generators/ttf.js
+++ b/src/generators/ttf.js
@@ -2,5 +2,5 @@ const svgSheetToTTF = require('svg2ttf');
 
 module.exports = fontSheet => new Promise(resolve => {
   const font = svgSheetToTTF(fontSheet);
-  resolve(new Buffer(font.buffer));
+  resolve(Buffer.from(font.buffer));
 });

--- a/src/generators/woff.js
+++ b/src/generators/woff.js
@@ -2,5 +2,5 @@ const TTFToWOFF = require('ttf2woff');
 
 module.exports = ttfBuffer => new Promise(resolve => {
   const font = TTFToWOFF(new Uint8Array(ttfBuffer));
-  resolve(new Buffer(font.buffer));
+  resolve(Buffer.from(font.buffer));
 });


### PR DESCRIPTION
### About
I was running into some quality issues when generating an icon font for the upcoming icon update. First I tried simplifying the svgs (`svgomg`) - but realized the svg files were already very simple. I then did a bit of digging around here and found a few possible updates.
 
The `fontHeight` option is the biggest improvement in font quality, got the idea from the warning message output:

`
A fontHeight of at least than 1000 is recommended, otherwise further steps (rounding in svg2ttf) could lead to ugly results. Use the fontHeight option to scale icons.
`

The font generated is the same size and takes the same time to generate.

I also updated the version of `svgicons2svgfont`, from `^5.0.0` to `^9.0.0` which also had a noticeable impact on quality. Arbitrarily chose `9.0.0` - it's ~3 years old and seemed like a nice round number. `¯\_(ツ)_/¯`
https://www.npmjs.com/package/svgicons2svgfont/v/9.1.1

Also updated `Buffer()` usage which was giving some deprecation warnings, and added `package-lock` to `.gitignore` because why not.

### Screenshots
**Before**
<img width="206" alt="Screen Shot 2020-11-30 at 3 04 23 PM" src="https://user-images.githubusercontent.com/2947034/100678673-8e0c2f80-3322-11eb-8b8d-aa644b473800.png">

**With fontHeight option**
<img width="212" alt="Screen Shot 2020-11-30 at 3 05 06 PM" src="https://user-images.githubusercontent.com/2947034/100678707-9b291e80-3322-11eb-9286-f776e2886089.png">

**After 9.0.0 update**
<img width="199" alt="Screen Shot 2020-11-30 at 3 05 29 PM" src="https://user-images.githubusercontent.com/2947034/100678731-a7ad7700-3322-11eb-8d04-b8e318a55ec4.png">

### 5.0.0 > 9.0.0 artifacts
**5.0.0**
<img width="208" alt="Screen Shot 2020-11-30 at 3 19 28 PM" src="https://user-images.githubusercontent.com/2947034/100678771-c0b62800-3322-11eb-8150-2f2b5d865d97.png">

**9.0.0**
<img width="196" alt="Screen Shot 2020-11-30 at 3 19 35 PM" src="https://user-images.githubusercontent.com/2947034/100678778-c6137280-3322-11eb-97c4-a34e645e9fe7.png">
